### PR TITLE
Rework env vars so port doesn't break app

### DIFF
--- a/features/auth.feature
+++ b/features/auth.feature
@@ -22,4 +22,4 @@ Feature: functional test cases
 			| accessLevel |
 			| one         |
 			| two         |
-			| ten         |
+			| three       |

--- a/local-example.env
+++ b/local-example.env
@@ -1,8 +1,12 @@
-# Secret for proxy JWT (required)
+# For proxy JWT (required)
 AUTH_COOKIE_NAME=
 AUTH_TOKEN_SECRET=
 
-# URLS for subcription files (required)
-AUTH_PROTECTED_URL=
-AUTH_URLS="site1:foo,site2:bar,site3:baz"
 MANAGEMENT_API=
+
+AUTH_SITE_ONE_LEVEL=
+AUTH_SITE_ONE=
+AUTH_SITE_TWO_LEVEL=
+AUTH_SITE_TWO=
+AUTH_SITE_THREE_LEVEL=
+AUTH_SITE_THREE=

--- a/main_test.go
+++ b/main_test.go
@@ -61,11 +61,11 @@ func Test_AuthProxy(t *testing.T) {
 	proxy := Proxy{
 		ManagementAPI: managementAPI,
 		auth: ProxyAuth{
-			cookieName,
-			tokenSecret,
-			authURLs,
+			CookieName:  cookieName,
+			TokenSecret: tokenSecret,
 		},
-		log: zap.L(),
+		sites: authURLs,
+		log:   zap.L(),
 	}
 
 	for _, tc := range tests {

--- a/test.env
+++ b/test.env
@@ -1,8 +1,12 @@
-MANAGEMENT_API="fakemanagementapi:3000"
-
 # For proxy JWT (required)
 AUTH_COOKIE_NAME="_proxy"
 AUTH_TOKEN_SECRET="Rm9yIEdvZCBzbyBsb3ZlZCB0aGUgd29ybGQgdGhhdCBoZSBnYXZlIGhpcyBvbmUgYW5kIG9ubHkgU29uLCB0aGF0IHdob2V2ZXIgYmVsaWV2ZXMgaW4gaGltIHNoYWxsIG5vdCBwZXJpc2ggYnV0IGhhdmUgZXRlcm5hbCBsaWZlLiAtIEpvaG4gMzoxNg=="
-# Use %3A instead of colon [:] for auth urls
-AUTH_URLS="one:server1%3A3000,two:server2%3A3000,ten:server3%3A3000"
 
+MANAGEMENT_API="fakemanagementapi:3000"
+
+AUTH_SITE_ONE_LEVEL="one"
+AUTH_SITE_ONE="server1:3000"
+AUTH_SITE_TWO_LEVEL="two"
+AUTH_SITE_TWO="server2:3000"
+AUTH_SITE_THREE_LEVEL="three"
+AUTH_SITE_THREE="server3:3000"


### PR DESCRIPTION
`kelseyhightower/envconfig` map decoder calls `Split` on `:` rather than use `SplitN` or `Cut`. This causes error if the env var value has a port, which Caddy seems to require. Changing to individual env variables for now.