### PR TITLE
fix envconfig

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -66,7 +66,7 @@ func sendRequest(url string, c *http.Cookie) error {
 }
 
 func weSendARequestWithValidAuthorizationDataAuthorizingAccess(level string) error {
-	c := makeTestJWTCookie(p.cookieName, p.tokenSecret, level, time.Now().AddDate(0, 0, 1))
+	c := makeTestJWTCookie(p.CookieName, p.TokenSecret, level, time.Now().AddDate(0, 0, 1))
 	return sendRequest(testURL, c)
 }
 
@@ -74,9 +74,9 @@ func weSendARequestWithAuthorizationData(t string) error {
 	var c *http.Cookie
 	switch t {
 	case "expired":
-		c = makeTestJWTCookie(p.cookieName, p.tokenSecret, "level", time.Now().AddDate(0, 0, -1))
+		c = makeTestJWTCookie(p.CookieName, p.TokenSecret, "level", time.Now().AddDate(0, 0, -1))
 	case "invalid":
-		c = makeTestJWTCookie(p.cookieName, "bad", "level", time.Now().AddDate(0, 0, 1))
+		c = makeTestJWTCookie(p.CookieName, "bad", "level", time.Now().AddDate(0, 0, 1))
 	case "no":
 		c = nil
 	default:
@@ -96,7 +96,7 @@ func weWillBeRedirectedToTheManagementApi() error {
 		return err
 	}
 
-	return assertEqual(p.managementAPI, loc.String())
+	return assertEqual(p.ManagementAPI, loc.String())
 }
 
 func weDoNotSeeAnErrorMessage() error {
@@ -109,7 +109,7 @@ func weWillSeeAnErrorMessage() error {
 
 func weWillSeeTheAccessLevelVersionOfTheWebsite(level string) error {
 	proxy := last
-	if err := sendRequest("http://"+p.sites[level], nil); err != nil {
+	if err := sendRequest("http://"+p.Sites[level], nil); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func (p Proxy) authRedirect(r *http.Request) (string, error) {
 		p.log.Info("jwt has expired")
 		return p.ManagementAPI, nil
 	} else if err != nil {
-		return "", err
+		return "", fmt.Errorf("authRedirect failed to parse token: %w", err)
 	}
 
 	result, ok := p.Sites[p.claim.Level]

--- a/main.go
+++ b/main.go
@@ -31,10 +31,10 @@ type ProxyClaim struct {
 }
 
 type Proxy struct {
-	cookieName    string    `required:"true" split_words:"true"`
-	tokenSecret   string    `required:"true" split_words:"true"`
-	sites         AuthSites `required:"true" split_words:"true"`
-	managementAPI string    `required:"true" split_words:"true"`
+	CookieName    string    `required:"true" split_words:"true"`
+	TokenSecret   string    `required:"true" split_words:"true"`
+	Sites         AuthSites `required:"true" split_words:"true"`
+	ManagementAPI string    `required:"true" split_words:"true"`
 
 	claim ProxyClaim  `ignored:"true"`
 	log   *zap.Logger `ignored:"true"`
@@ -72,10 +72,10 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.
 
 func (p Proxy) authRedirect(r *http.Request) (string, error) {
 	// if no cookie, redirect to get new cookie
-	cookie, err := r.Cookie(p.cookieName)
+	cookie, err := r.Cookie(p.CookieName)
 	if err != nil {
 		p.log.Info("no jwt exists, calling management api")
-		return p.managementAPI, nil
+		return p.ManagementAPI, nil
 	}
 
 	_, err = jwt.ParseWithClaims(cookie.Value, &p.claim, func(token *jwt.Token) (interface{}, error) {
@@ -83,16 +83,16 @@ func (p Proxy) authRedirect(r *http.Request) (string, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 
-		return []byte(p.tokenSecret), nil
+		return []byte(p.TokenSecret), nil
 	})
 	if errors.Is(err, jwt.ErrTokenExpired) {
 		p.log.Info("jwt has expired")
-		return p.managementAPI, nil
+		return p.ManagementAPI, nil
 	} else if err != nil {
 		return "", err
 	}
 
-	result, ok := p.sites[p.claim.Level]
+	result, ok := p.Sites[p.claim.Level]
 	if !ok {
 		return "", fmt.Errorf("unknown auth level: %v", p.claim.Level)
 	}
@@ -110,11 +110,11 @@ func newProxy() (Proxy, error) {
 		return p, err
 	}
 
-	secret, err := base64.StdEncoding.DecodeString(p.tokenSecret)
+	secret, err := base64.StdEncoding.DecodeString(p.TokenSecret)
 	if err != nil {
 		return p, fmt.Errorf("unable to decode Proxy TokenSecret: %w", err)
 	}
-	p.tokenSecret = string(secret)
+	p.TokenSecret = string(secret)
 
 	return p, err
 }

--- a/main_test.go
+++ b/main_test.go
@@ -20,9 +20,9 @@ func Test_AuthProxy(t *testing.T) {
 	validTime := time.Now().AddDate(0, 0, 1)
 	expiredTime := time.Now().AddDate(0, 0, -1)
 	proxy := Proxy{
-		cookieName:  cookieName,
-		tokenSecret: tokenSecret,
-		sites:       authURLs,
+		CookieName:  cookieName,
+		TokenSecret: tokenSecret,
+		Sites:       authURLs,
 		log:         zap.L(),
 	}
 


### PR DESCRIPTION
### Fixed
- Export struct fields so envconfig can write to them
- Add error message context to `jwt.ParseWithClaims` error