### PR TITLE
Set a cookie from the token obtained from the management API

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -9,6 +9,6 @@
 	@management_api expression {vars.upstream} == "{$MANAGEMENT_API}"
 	@static_site expression {vars.upstream} != "{$MANAGEMENT_API}"
 
-	redir @management_api "{$MANAGEMENT_API}?returnTo={uri}"
+	redir @management_api "{$MANAGEMENT_API}?returnTo={vars.returnTo}"
 	reverse_proxy @static_site {vars.upstream}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -6,9 +6,9 @@
 	encode zstd gzip
 	dynamic_proxy
 
-	@redirect expression {vars.upstream} == "{$MANAGEMENT_API}"
-	@reverseproxy expression {vars.upstream} != "{$MANAGEMENT_API}"
+	@management_api expression {vars.upstream} == "{$MANAGEMENT_API}"
+	@static_site expression {vars.upstream} != "{$MANAGEMENT_API}"
 
-	redir @redirect "{$MANAGEMENT_API}?returnTo={uri}"
-	reverse_proxy @reverseproxy {vars.upstream}
+	redir @management_api "{$MANAGEMENT_API}?returnTo={uri}"
+	reverse_proxy @static_site {vars.upstream}
 }

--- a/functional_test.go
+++ b/functional_test.go
@@ -37,7 +37,7 @@ func Test_Functional(t *testing.T) {
 		ScenarioInitializer: InitializeScenario,
 	}.Run()
 
-	assert.Equal(t, 0, status)
+	assert.Equal(t, 0, status, "One or more functional tests failed.")
 }
 
 func sendRequest(url string, c *http.Cookie) error {
@@ -86,7 +86,8 @@ func weSendARequestWithAuthorizationData(t string) error {
 }
 
 func weWillBeRedirectedToTheManagementApi() error {
-	err := assertEqual(http.StatusTemporaryRedirect, last.response.StatusCode)
+	err := assertEqual(http.StatusTemporaryRedirect, last.response.StatusCode,
+		"response: %s", last.body)
 	if err != nil {
 		return err
 	}

--- a/functional_test.go
+++ b/functional_test.go
@@ -66,7 +66,7 @@ func sendRequest(url string, c *http.Cookie) error {
 }
 
 func weSendARequestWithValidAuthorizationDataAuthorizingAccess(level string) error {
-	c := makeTestJWTCookie(p.CookieName, p.TokenSecret, level, time.Now().AddDate(0, 0, 1))
+	c := makeTestJWTCookie(p.CookieName, p.Secret, level, time.Now().AddDate(0, 0, 1))
 	return sendRequest(testURL, c)
 }
 
@@ -74,9 +74,9 @@ func weSendARequestWithAuthorizationData(t string) error {
 	var c *http.Cookie
 	switch t {
 	case "expired":
-		c = makeTestJWTCookie(p.CookieName, p.TokenSecret, "level", time.Now().AddDate(0, 0, -1))
+		c = makeTestJWTCookie(p.CookieName, p.Secret, "level", time.Now().AddDate(0, 0, -1))
 	case "invalid":
-		c = makeTestJWTCookie(p.CookieName, "bad", "level", time.Now().AddDate(0, 0, 1))
+		c = makeTestJWTCookie(p.CookieName, []byte("bad"), "level", time.Now().AddDate(0, 0, 1))
 	case "no":
 		c = nil
 	default:

--- a/local-example.env
+++ b/local-example.env
@@ -1,3 +1,5 @@
+# This host, e.g. http://auth-proxy.example.com
+HOST=http://auth-proxy.example.com
 # For proxy JWT (required)
 COOKIE_NAME=
 # base64 encoded string

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -33,6 +32,7 @@ type ProxyClaim struct {
 }
 
 type Proxy struct {
+	Host          string    `required:"true"`
 	CookieName    string    `required:"true" split_words:"true"`
 	TokenSecret   string    `required:"true" split_words:"true"`
 	Sites         AuthSites `required:"true" split_words:"true"`
@@ -81,7 +81,7 @@ func (p Proxy) authRedirect(w http.ResponseWriter, r *http.Request) (string, err
 	if token == "" {
 		p.log.Info("no token found, calling management api!")
 
-		returnTo := url.QueryEscape(os.Getenv("HOST") + r.URL.Path)
+		returnTo := url.QueryEscape(p.Host + r.URL.Path)
 		caddyhttp.SetVar(r.Context(), "returnTo", returnTo)
 		p.log.Info("setting returnTo to " + returnTo)
 

--- a/main.go
+++ b/main.go
@@ -33,10 +33,13 @@ type ProxyClaim struct {
 
 type Proxy struct {
 	Host          string    `required:"true"`
-	CookieName    string    `required:"true" split_words:"true"`
 	TokenSecret   string    `required:"true" split_words:"true"`
 	Sites         AuthSites `required:"true" split_words:"true"`
 	ManagementAPI string    `required:"true" split_words:"true"`
+
+	// optional params
+	CookieName     string `default:"_auth_proxy" split_words:"true"`
+	TokenParameter string `default:"token" split_words:"true"`
 
 	// Secret is the binary token secret. Must be exported to be valid after being passed back from Caddy.
 	Secret []byte `ignored:"true"`
@@ -141,5 +144,5 @@ func (p Proxy) getToken(r *http.Request) string {
 	if err == nil {
 		return cookie.Value
 	}
-	return r.URL.Query().Get("setToken")
+	return r.URL.Query().Get(p.TokenParameter)
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
+	"os"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -75,6 +77,11 @@ func (p Proxy) authRedirect(r *http.Request) (string, error) {
 	cookie, err := r.Cookie(p.CookieName)
 	if err != nil {
 		p.log.Info("no jwt exists, calling management api")
+
+		returnTo := url.QueryEscape(os.Getenv("HOST") + r.URL.Path)
+		caddyhttp.SetVar(r.Context(), "returnTo", returnTo)
+		p.log.Info("setting returnTo to " + returnTo)
+
 		return p.ManagementAPI, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func (p Proxy) authRedirect(w http.ResponseWriter, r *http.Request) (string, err
 
 	result, ok := p.Sites[p.claim.Level]
 	if !ok {
-		return "", fmt.Errorf("unknown auth level: %v", p.claim.Level)
+		return "", fmt.Errorf("auth level '%v' not in sites: %v", p.claim.Level, p.Sites)
 	}
 
 	return result, nil

--- a/main_test.go
+++ b/main_test.go
@@ -72,7 +72,8 @@ func Test_AuthProxy(t *testing.T) {
 				r.AddCookie(tc.cookie)
 			}
 
-			to, err := proxy.authRedirect(r)
+			var w httptest.ResponseRecorder
+			to, err := proxy.authRedirect(&w, r)
 			if tc.wantErr {
 				assert.ErrorContains(err, tc.want)
 			} else {

--- a/main_test.go
+++ b/main_test.go
@@ -14,16 +14,16 @@ import (
 func Test_AuthProxy(t *testing.T) {
 	assert := assert.New(t)
 	cookieName := "_test"
-	tokenSecret := "secret"
+	tokenSecret := []byte("secret")
 	managementAPI := "management_api"
 	authURLs := AuthSites{"good": "good url"}
 	validTime := time.Now().AddDate(0, 0, 1)
 	expiredTime := time.Now().AddDate(0, 0, -1)
 	proxy := Proxy{
-		CookieName:  cookieName,
-		TokenSecret: tokenSecret,
-		Sites:       authURLs,
-		log:         zap.L(),
+		CookieName: cookieName,
+		Secret:     tokenSecret,
+		Sites:      authURLs,
+		log:        zap.L(),
 	}
 
 	tests := []struct {
@@ -40,7 +40,7 @@ func Test_AuthProxy(t *testing.T) {
 		},
 		{
 			name:    "invalid cookie",
-			cookie:  makeTestJWTCookie(cookieName, "bad", "good", validTime),
+			cookie:  makeTestJWTCookie(cookieName, []byte("bad"), "good", validTime),
 			wantErr: true,
 			want:    "signature is invalid",
 		},
@@ -83,7 +83,7 @@ func Test_AuthProxy(t *testing.T) {
 	}
 }
 
-func makeTestJWTCookie(name, secret, level string, expires time.Time) *http.Cookie {
+func makeTestJWTCookie(name string, secret []byte, level string, expires time.Time) *http.Cookie {
 	claim := ProxyClaim{
 		Level: level,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -92,7 +92,7 @@ func makeTestJWTCookie(name, secret, level string, expires time.Time) *http.Cook
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claim)
-	tokenString, _ := token.SignedString([]byte(secret))
+	tokenString, _ := token.SignedString(secret)
 
 	return &http.Cookie{
 		Name:  name,


### PR DESCRIPTION
### Changed
- Get a token from the management API and set it as a cookie.
- Changed the names of the Caddyfile matchers to represent the server (`management_api` and `static_site`), not the action (`redirect` and `reverseproxy`).
### Fixed
- The jwt secret was being mangled by Caddy. Setting the decoded version as a separate field on the struct seems to fix this.
- The redirect `returnTo` parameter needed to be a full URL, not just the path found in the `uri` placeholder.