### PR TITLE
dev environment helps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     env_file: local.env
     volumes:
       - ./:/app
+      - go-build:/root/.cache/go-build
+      - go-mod:/go/pkg/mod
 
   testapp:
     build:
@@ -67,3 +69,7 @@ services:
     volumes:
       - ./Caddyfile-test:/srv/Caddyfile
     command: caddy run
+
+volumes:
+  go-build: {}
+  go-mod: {}

--- a/functional_test.go
+++ b/functional_test.go
@@ -24,15 +24,11 @@ var (
 )
 
 func Test_Functional(t *testing.T) {
-	// setup
-	var err error
-	p, err = newProxy()
-	assert.NoError(t, err)
-
 	// run functional tests
 	status := godog.TestSuite{
-		Name:                "functional tests",
-		ScenarioInitializer: InitializeScenario,
+		Name:                 "functional tests",
+		ScenarioInitializer:  InitializeScenario,
+		TestSuiteInitializer: InitializeTestSuite,
 	}.Run()
 
 	assert.Equal(t, 0, status, "One or more functional tests failed.")
@@ -104,6 +100,15 @@ func weWillSeeTheAccessLevelVersionOfTheWebsite(level string) error {
 	}
 
 	return assertEqual(last.body, proxy.body)
+}
+
+func InitializeTestSuite(ctx *godog.TestSuiteContext) {
+	ctx.BeforeSuite(func() {
+		var err error
+		if p, err = newProxy(); err != nil {
+			panic(err.Error())
+		}
+	})
 }
 
 func InitializeScenario(ctx *godog.ScenarioContext) {

--- a/functional_test.go
+++ b/functional_test.go
@@ -23,8 +23,6 @@ var (
 	client = http.DefaultClient
 )
 
-const testURL = "http://testapp"
-
 func Test_Functional(t *testing.T) {
 	// setup
 	var err error
@@ -67,7 +65,7 @@ func sendRequest(url string, c *http.Cookie) error {
 
 func weSendARequestWithValidAuthorizationDataAuthorizingAccess(level string) error {
 	c := makeTestJWTCookie(p.CookieName, p.Secret, level, time.Now().AddDate(0, 0, 1))
-	return sendRequest(testURL, c)
+	return sendRequest(p.Host, c)
 }
 
 func weSendARequestWithAuthorizationData(t string) error {
@@ -82,7 +80,7 @@ func weSendARequestWithAuthorizationData(t string) error {
 	default:
 		return godog.ErrPending
 	}
-	return sendRequest(testURL, c)
+	return sendRequest(p.Host, c)
 }
 
 func weWillBeRedirectedToTheManagementApi() error {


### PR DESCRIPTION
- put Go build cache and module cache in docker volumes to speed up container startup
- move the `newProxy` call into a godog suite initializer
  - allows for running tests using `godog run`, which helps when you only want to run one scenario
- use `p.Host` (HOST env var) instead of a `const`