### PR TITLE
use the full redirect path

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -9,6 +9,6 @@
 	@management_api expression {vars.upstream}.startsWith('{$MANAGEMENT_API}')
 	@static_site expression !{vars.upstream}.startsWith('{$MANAGEMENT_API}"')
 
-	redir @management_api "{$MANAGEMENT_API}?returnTo={vars.returnTo}"
+	redir @management_api "{vars.upstream}?returnTo={vars.returnTo}"
 	reverse_proxy @static_site {vars.upstream}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -9,6 +9,10 @@
 	@management_api expression {vars.upstream}.startsWith('{$MANAGEMENT_API}')
 	@static_site expression !{vars.upstream}.startsWith('{$MANAGEMENT_API}"')
 
+	# redirect to the management api with a returnTo parameter
 	redir @management_api "{vars.upstream}?returnTo={vars.returnTo}"
+
+	# remove query string and proxy to upstream specified in vars.upstream
+	rewrite @static_site {path}?
 	reverse_proxy @static_site {vars.upstream}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -7,7 +7,7 @@
 	dynamic_proxy
 
 	@management_api expression {vars.upstream}.startsWith('{$MANAGEMENT_API}')
-	@static_site expression {vars.upstream} != "{$MANAGEMENT_API}"
+	@static_site expression !{vars.upstream}.startsWith('{$MANAGEMENT_API}"')
 
 	redir @management_api "{$MANAGEMENT_API}?returnTo={vars.returnTo}"
 	reverse_proxy @static_site {vars.upstream}


### PR DESCRIPTION
### Fixed
- After moving the management API path into a separate variable, it got dropped in the redirect. This brings it back into the redirect path.
- Static site matcher was not quite right.
### Added
- Clear the query string after storing the token in the cookie.