### PR TITLE
use a redirect to clear the query string

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -8,12 +8,14 @@
 
 	@management_api expression {vars.upstream}.startsWith('{$MANAGEMENT_API}')
 	@static_site expression !{vars.upstream}.startsWith('{$MANAGEMENT_API}')
+	@clear_query expression {vars.clear_query} == "true"
 
 	# redirect to the management api with a returnTo parameter
 	redir @management_api "{vars.upstream}?returnTo={vars.returnTo}"
 
-	# remove query string and proxy to upstream specified in vars.upstream
-	rewrite @static_site {path}?
+	# redirect back to the auth-proxy, but to the path without the query string
+	redir @clear_query {path}
+
 	reverse_proxy @static_site {vars.upstream} {
 		header_up Host {vars.upstream}
 	}

--- a/Caddyfile-test
+++ b/Caddyfile-test
@@ -1,5 +1,15 @@
 :80
 respond 200 {
-	body "{$SERVER} -- {$HOSTNAME} {uri}
-			host: {host}"
+	body "<!DOCTYPE html>
+		<html>
+			<head>
+				<title>{$SERVER}</title>
+			</head>
+			<body>
+					<p><b>hostname:</b> {$HOSTNAME}</p>
+					<p><b>uri:</b> {uri}</p>
+					<p><b>host:</b> {host}<p>
+			</body>
+		</html>
+"
 }

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -2,6 +2,8 @@ testapp:
   build:
     context: .
     dockerfile: Dockerfile
+  cached: true
+  default_cache_branch: "develop"
   env_file: test.env
   command: caddy run
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -80,7 +80,7 @@ func weSendARequestWithAuthorizationData(t string) error {
 }
 
 func weWillBeRedirectedToTheManagementApi() error {
-	return assertContains(last.body[:7], "<title>API</title>",
+	return assertContains(last.body, "<title>API</title>",
 		`did not see "API" in the response body title: %s`, last.body)
 }
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -80,8 +80,8 @@ func weSendARequestWithAuthorizationData(t string) error {
 }
 
 func weWillBeRedirectedToTheManagementApi() error {
-	return assertEqual("API -- ", last.body[:7],
-		`did not see "API --" in the response body: %s`, last.body)
+	return assertEqual("<title>API</title>", last.body[:7],
+		`did not see "API" in the response body: %s`, last.body)
 }
 
 func weDoNotSeeAnErrorMessage() error {

--- a/functional_test.go
+++ b/functional_test.go
@@ -80,8 +80,8 @@ func weSendARequestWithAuthorizationData(t string) error {
 }
 
 func weWillBeRedirectedToTheManagementApi() error {
-	return assertEqual("<title>API</title>", last.body[:7],
-		`did not see "API" in the response body: %s`, last.body)
+	return assertContains(last.body[:7], "<title>API</title>",
+		`did not see "API" in the response body title: %s`, last.body)
 }
 
 func weDoNotSeeAnErrorMessage() error {
@@ -139,5 +139,11 @@ func (a *asserter) Errorf(format string, args ...interface{}) {
 func assertEqual(expected, actual interface{}, msgAndArgs ...interface{}) error {
 	var a asserter
 	assert.Equal(&a, expected, actual, msgAndArgs...)
+	return a.err
+}
+
+func assertContains(s, contains interface{}, msgAndArgs ...interface{}) error {
+	var a asserter
+	assert.Contains(&a, s, contains, msgAndArgs...)
 	return a.err
 }

--- a/main.go
+++ b/main.go
@@ -156,6 +156,8 @@ func newProxy() (Proxy, error) {
 // getToken returns a token found in either a cookie or the query string
 func (p Proxy) getToken(r *http.Request) string {
 	if token := r.URL.Query().Get(p.TokenParam); token != "" {
+		// if we got the token from the address bar, set a flag for the Caddyfile to redirect without it
+		p.setVar(r, "clear_query", "true")
 		return token
 	}
 	if cookie, err := r.Cookie(p.CookieName); err == nil {

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func newProxy() (Proxy, error) {
 // getToken returns a token found in either a cookie or the query string
 func (p Proxy) getToken(r *http.Request) string {
 	if token := r.URL.Query().Get(p.TokenParam); token != "" {
-		// if we got the token from the address bar, set a flag for the Caddyfile to redirect without it
+		// if we got the token from the query string, set a flag for the Caddyfile to redirect without it
 		p.setVar(r, "clear_query", "true")
 		return token
 	}


### PR DESCRIPTION
### Fixed
- Fixed the mechanism for clearing the query string after getting the token from it
### Added
- Added debug information to the dev/test Caddyfile