### PR TITLE
return 400 for errors produced by bad input

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -89,8 +89,8 @@ func weDoNotSeeAnErrorMessage() error {
 }
 
 func weWillSeeAnErrorMessage() error {
-	return assertEqual(http.StatusInternalServerError, last.response.StatusCode,
-		"expected a 500, --%s-- got a %d, body: %s", p.Host, last.response.StatusCode, last.body)
+	return assertEqual(http.StatusBadRequest, last.response.StatusCode,
+		"expected a 400, --%s-- got a %d, body: %s", p.Host, last.response.StatusCode, last.body)
 }
 
 func weWillSeeTheAccessLevelVersionOfTheWebsite(level string) error {

--- a/main_test.go
+++ b/main_test.go
@@ -77,7 +77,7 @@ func Test_AuthProxy(t *testing.T) {
 			if tc.wantErr {
 				assert.ErrorContains(err, tc.want)
 			} else {
-				assert.NoError(err)
+				assert.Nil(err)
 				assert.Equal(tc.want, to)
 			}
 		})


### PR DESCRIPTION
### Fixed
- Return http 400 status for errors resulting from conditions such as a bad JWT 