### PR TITLE
Prevent static site content from being cached

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -22,6 +22,7 @@
 
 	reverse_proxy @static_site {vars.upstream} {
 		header_up Host {vars.upstream}
+		header_down +Cache-Control "no-store"
 	}
 
 #	log {


### PR DESCRIPTION
### Fixed
- Prevent static site content from being cached

---

We do not want user's browsers caching the static website content, to ensure that when someone logs out, they see content from the appropriate S3 bucket, not a cached copy of content from a different S3 bucket.