### PR TITLE
redirect directly instead of leaving it to Caddy

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,9 +158,11 @@ func (p Proxy) authRedirect(w http.ResponseWriter, r *http.Request) (string, *Er
 	}
 
 	returnTo := r.URL.Query().Get(p.ReturnToParam)
+	p.log.Info("returnTo", zap.String(p.ReturnToParam, returnTo), zap.String("url", r.URL.String()))
 	if returnTo != "" && p.isTrusted(returnTo) {
 		p.log.Info("redirecting", zap.String("url", returnTo))
-		return returnTo, nil
+		w.Header().Set("location", returnTo)
+		w.WriteHeader(http.StatusTemporaryRedirect)
 	}
 	return result, nil
 }

--- a/main.go
+++ b/main.go
@@ -158,10 +158,11 @@ func (p Proxy) authRedirect(w http.ResponseWriter, r *http.Request) (string, *Er
 	}
 
 	returnTo := r.URL.Query().Get(p.ReturnToParam)
-	p.log.Info("returnTo", zap.String(p.ReturnToParam, returnTo), zap.String("url", r.URL.String()))
 	if returnTo != "" && p.isTrusted(returnTo) {
 		p.log.Info("redirecting", zap.String("url", returnTo))
 		w.Header().Set("location", returnTo)
+
+		// Note: further processing of Caddy modules is inhibited by this
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	}
 	return result, nil


### PR DESCRIPTION
### Fixed
- When we get a `returnTo` with a full path that begins with the CAM or proxy URL, immediately redirect instead of leaving it to Caddy. The Caddy reverse proxy module doesn't accept a URL with a path.

[ETH-877](https://itse.youtrack.cloud/issue/ETH-877)