### PR TITLE
redefine the Caddy vars and Caddyfile to make a more versatile redirect

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -6,19 +6,11 @@
 	encode zstd gzip
 	dynamic_proxy
 
-	@management_api_with_returnto expression {vars.upstream}.startsWith('{$MANAGEMENT_API}') && {vars.returnTo} != ""
-	@management_api expression {vars.upstream}.startsWith('{$MANAGEMENT_API}')
-	@static_site expression !{vars.upstream}.startsWith('{$MANAGEMENT_API}')
-	@clear_query expression {vars.clear_query} == "true"
+	@redirect expression "{vars.redirect_url} != null"
+	@static_site expression "{vars.upstream} != null"
 
-	# redirect to the management api with a returnTo parameter
-	redir @management_api_with_returnto "{vars.upstream}?returnTo={vars.returnTo}"
-
-	# redirect to the management api without a returnTo parameter
-	redir @management_api "{vars.upstream}"
-
-	# redirect back to the auth-proxy, but to the path without the query string
-	redir @clear_query {path}
+	# redirect to a URL
+	redir @redirect {vars.redirect_url}
 
 	reverse_proxy @static_site {vars.upstream} {
 		header_up Host {vars.upstream}

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.
 		return nil
 	}
 
-	err := p.authRedirect(w, r)
+	if err := p.authRedirect(w, r); err != nil {
 	if err != nil {
 		w.WriteHeader(err.Status)
 		_, writeErr := w.Write([]byte(err.Message))

--- a/main.go
+++ b/main.go
@@ -97,7 +97,6 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.
 	}
 
 	if err := p.authRedirect(w, r); err != nil {
-	if err != nil {
 		w.WriteHeader(err.Status)
 		_, writeErr := w.Write([]byte(err.Message))
 		if writeErr != nil {


### PR DESCRIPTION
### Changed
- Simplified the Caddyfile to use only two input variables: `redirect_url` and `upstream`.
- Changed `authRedirect` to use Caddy variables instead of a return value for the redirect and upstream values.