### PR TITLE
retain other query parameters when stripping the token from the URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,10 +206,16 @@ func newProxy() (Proxy, error) {
 // variable to force a redirect to clear it from the query string.
 func (p Proxy) getToken(r *http.Request) string {
 	if token := r.URL.Query().Get(p.TokenParam); token != "" {
-		// if we got the token from the query string, set a flag for the Caddyfile to redirect without it
-		p.setVar(r, CaddyVarRedirectURL, r.URL.Path)
+		// if we got the token from the query string, set a URL for the Caddyfile to redirect without it
+		u := r.URL
+		q := u.Query()
+		q.Del(p.TokenParam)
+		u.RawQuery = q.Encode()
+
+		p.setVar(r, CaddyVarRedirectURL, u.String())
 		return token
 	}
+
 	if cookie, err := r.Cookie(p.CookieName); err == nil {
 		return cookie.Value
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -117,14 +117,12 @@ func Test_getToken(t *testing.T) {
 
 	testJWT := makeTestJWT(secret, "good", time.Now().AddDate(0, 0, 1))
 
-	redirectURL := "/"
-
 	tests := []struct {
 		name            string
 		cookie          *http.Cookie
 		query           string
 		want            string
-		wantRedirectURL *string
+		wantRedirectURL string
 	}{
 		{
 			name: "no token",
@@ -134,7 +132,7 @@ func Test_getToken(t *testing.T) {
 			name:            "token in URL param",
 			query:           tokenParam + "=abc123",
 			want:            "abc123",
-			wantRedirectURL: &redirectURL,
+			wantRedirectURL: "/",
 		},
 		{
 			name:   "token in cookie",
@@ -146,7 +144,13 @@ func Test_getToken(t *testing.T) {
 			cookie:          makeTestJWTCookie(cookieName, testJWT),
 			query:           tokenParam + "=abc123",
 			want:            "abc123",
-			wantRedirectURL: &redirectURL,
+			wantRedirectURL: "/",
+		},
+		{
+			name:            "token and returnTo in URL params",
+			query:           tokenParam + "=abc123&returnTo=https%3A%2F%2Fexample.com%2Fpath",
+			want:            "abc123",
+			wantRedirectURL: "/?returnTo=https%3A%2F%2Fexample.com%2Fpath",
 		},
 	}
 
@@ -162,8 +166,8 @@ func Test_getToken(t *testing.T) {
 
 			token := proxy.getToken(r)
 			assrt.Equal(tc.want, token)
-			if tc.wantRedirectURL != nil {
-				assrt.Equal(*tc.wantRedirectURL, caddyhttp.GetVar(r.Context(), CaddyVarRedirectURL))
+			if tc.wantRedirectURL != "" {
+				assrt.Equal(tc.wantRedirectURL, caddyhttp.GetVar(r.Context(), CaddyVarRedirectURL))
 			}
 		})
 	}


### PR DESCRIPTION
### Fixed
- Retain other query parameters when redirecting to remove the token from the URL

[ETH-877](https://itse.youtrack.cloud/issue/ETH-877)