### PR TITLE
ETH-135 part 1 -- refactor to facilitate further work

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.
 		return nil
 	}
 
-	if err := p.authRedirect(w, r); err != nil {
+	if err := p.handleRequest(w, r); err != nil {
 		var proxyError *Error
 		if errors.As(err, &proxyError) {
 			w.WriteHeader(proxyError.Status)
@@ -111,7 +111,7 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.
 	return next.ServeHTTP(w, r)
 }
 
-func (p Proxy) authRedirect(w http.ResponseWriter, r *http.Request) error {
+func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 	token := p.getToken(r)
 
 	if token == "" {
@@ -127,7 +127,7 @@ func (p Proxy) authRedirect(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	} else if err != nil {
 		return &Error{
-			err:     fmt.Errorf("authRedirect failed to parse token: %w", err),
+			err:     fmt.Errorf("handleRequest failed to parse token: %w", err),
 			Message: "error: corrupted access token",
 			Status:  http.StatusBadRequest,
 		}

--- a/main.go
+++ b/main.go
@@ -141,15 +141,15 @@ func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 	}
 	http.SetCookie(w, &ck)
 
-	upstream, err := p.getSite(claim.Level)
-	if err != nil {
-		return err
-	}
-
 	returnTo := r.URL.Query().Get(p.ReturnToParam)
 	if returnTo != "" && p.isTrusted(returnTo) {
 		p.setVar(r, CaddyVarRedirectURL, returnTo)
 		return nil
+	}
+
+	upstream, err := p.getSite(claim.Level)
+	if err != nil {
+		return err
 	}
 
 	p.setVar(r, CaddyVarUpstream, upstream)

--- a/main_test.go
+++ b/main_test.go
@@ -83,7 +83,7 @@ func Test_AuthProxy(t *testing.T) {
 			r = r.WithContext(ctx)
 
 			var w httptest.ResponseRecorder
-			err := proxy.authRedirect(&w, r)
+			err := proxy.handleRequest(&w, r)
 
 			if tc.wantErr != "" {
 				assert.ErrorContains(err, tc.wantErr)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 
+RED='\033[0;31m'
+RESET='\033[0m'
+
 go test
+
+if [ $? -ne 0 ]; then
+  echo -e "\n${RED}One or more tests failed. If this is unexpected, it may be because the test server was still building.${RESET}"
+fi


### PR DESCRIPTION
### Changed (non-breaking)
- Rename `authRedirect` to `handleRequest` and change its return type to `error`
- Extract new function `getClaimFromToken`
- Extract new function `getSite`
- Move the `upstream` assignment nearer to the end of `handleRequest`
- Removed the `claim` field from `Proxy`
- Restructured `getToken`