### PR TITLE
ETH-135 part 2 -- fix redirect loop

### DIFF
--- a/Caddyfile-test
+++ b/Caddyfile-test
@@ -7,7 +7,7 @@ respond 200 {
 			</head>
 			<body>
 					<p><b>hostname:</b> {$HOSTNAME}</p>
-					<p><b>uri:</b> {uri}</p>
+					<p><b>path:</b> {path}</p>
 					<p><b>host:</b> {host}<p>
 			</body>
 		</html>

--- a/features/auth.feature
+++ b/features/auth.feature
@@ -11,12 +11,12 @@ Feature: functional test cases
 
 	Scenario: Invalid authorization data
 		When we send a request with invalid authorization data
-		Then we will see an error message
+		Then we do not see an error message
+		And we will be redirected to the management api
 
 	Scenario Outline: Authorization data specifying various levels of access
 		When we send a request with authorization data in the <urlOrCookie> authorizing <accessLevel> access
 		Then we do not see an error message
-		And we do not see the token parameter
 		And we will see the <accessLevel> version of the website
 
 		Examples:

--- a/main.go
+++ b/main.go
@@ -144,14 +144,7 @@ func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 
 	flag := p.getFlag(r)
 	if !flag && !cookieClaim.IsValid {
-		p.log.Info("setting cookie")
-		ck := http.Cookie{
-			Name:    p.CookieName,
-			Value:   token,
-			Expires: claim.ExpiresAt.Time,
-			Path:    "/",
-		}
-		http.SetCookie(w, &ck)
+		p.setCookie(w, token, claim.ExpiresAt.Time)
 		p.setFlag(r)
 		return nil
 	}
@@ -244,11 +237,11 @@ func (p Proxy) clearQsToken(r *http.Request) {
 	p.setVar(r, CaddyVarRedirectURL, u.String())
 }
 
-func (p Proxy) setCookie(w http.ResponseWriter, token string) {
+func (p Proxy) setCookie(w http.ResponseWriter, token string, expiry time.Time) {
 	ck := http.Cookie{
 		Name:    p.CookieName,
 		Value:   token,
-		Expires: time.Now().AddDate(0, 0, 1),
+		Expires: expiry,
 		Path:    "/",
 	}
 	http.SetCookie(w, &ck)

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 
 	if flag && cookieClaim.IsValid {
 		p.log.Info("clearing flag")
-		p.clearQsToken(r)
+		p.clearQueryToken(r)
 		p.clearFlag(r)
 		return nil
 	}
@@ -225,7 +225,7 @@ func (p Proxy) getSite(level string) (string, error) {
 	return upstream, nil
 }
 
-func (p Proxy) clearQsToken(r *http.Request) {
+func (p Proxy) clearQueryToken(r *http.Request) {
 	u := r.URL
 	q := u.Query()
 	q.Del(p.TokenParam)

--- a/main.go
+++ b/main.go
@@ -137,9 +137,6 @@ func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 	} else if cookieClaim.IsValid {
 		token = cookieToken
 		claim = cookieClaim
-	} else {
-		token = ""
-		claim = ProxyClaim{}
 	}
 
 	flag := p.getFlag(r)

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,6 @@ func Test_AuthProxy(t *testing.T) {
 	const managementAPI = "http://management_api.example.com"
 	const tokenPath = "/auth/token"
 
-	assert := assert.New(t)
 	cookieName := "_test"
 	tokenSecret := []byte("secret")
 	authURLs := AuthSites{"good": "good url"}
@@ -48,11 +47,6 @@ func Test_AuthProxy(t *testing.T) {
 			cookie:          nil,
 			wantErr:         "",
 			wantRedirectURL: &redirectURL,
-		},
-		{
-			name:    "invalid cookie",
-			cookie:  makeTestJWTCookie(cookieName, makeTestJWT([]byte("bad"), "good", validTime)),
-			wantErr: "signature is invalid",
 		},
 		{
 			name:            "expired cookie",
@@ -86,16 +80,16 @@ func Test_AuthProxy(t *testing.T) {
 			err := proxy.handleRequest(&w, r)
 
 			if tc.wantErr != "" {
-				assert.ErrorContains(err, tc.wantErr)
+				assert.ErrorContains(t, err, tc.wantErr)
 				return
 			}
-			assert.Nil(err)
+			assert.Nil(t, err)
 
 			if tc.wantUpstream != nil {
-				assert.Equal(*tc.wantUpstream, caddyhttp.GetVar(r.Context(), CaddyVarUpstream))
+				assert.Equal(t, *tc.wantUpstream, caddyhttp.GetVar(r.Context(), CaddyVarUpstream))
 			}
 			if tc.wantRedirectURL != nil {
-				assert.Equal(*tc.wantRedirectURL, caddyhttp.GetVar(r.Context(), CaddyVarRedirectURL))
+				assert.Equal(t, *tc.wantRedirectURL, caddyhttp.GetVar(r.Context(), CaddyVarRedirectURL))
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -101,9 +101,7 @@ func Test_AuthProxy(t *testing.T) {
 	}
 }
 
-func Test_getToken(t *testing.T) {
-	assrt := assert.New(t)
-
+func Test_getTokenFromCookie(t *testing.T) {
 	const cookieName = "cookie"
 	secret := []byte("secret")
 	const tokenParam = "token"
@@ -118,39 +116,19 @@ func Test_getToken(t *testing.T) {
 	testJWT := makeTestJWT(secret, "good", time.Now().AddDate(0, 0, 1))
 
 	tests := []struct {
-		name            string
-		cookie          *http.Cookie
-		query           string
-		want            string
-		wantRedirectURL string
+		name   string
+		cookie *http.Cookie
+		query  string
+		want   string
 	}{
 		{
 			name: "no token",
 			want: "",
 		},
 		{
-			name:            "token in URL param",
-			query:           tokenParam + "=abc123",
-			want:            "abc123",
-			wantRedirectURL: "/",
-		},
-		{
 			name:   "token in cookie",
 			cookie: makeTestJWTCookie(cookieName, testJWT),
 			want:   testJWT,
-		},
-		{
-			name:            "token in param and cookie",
-			cookie:          makeTestJWTCookie(cookieName, testJWT),
-			query:           tokenParam + "=abc123",
-			want:            "abc123",
-			wantRedirectURL: "/",
-		},
-		{
-			name:            "token and returnTo in URL params",
-			query:           tokenParam + "=abc123&returnTo=https%3A%2F%2Fexample.com%2Fpath",
-			want:            "abc123",
-			wantRedirectURL: "/?returnTo=https%3A%2F%2Fexample.com%2Fpath",
 		},
 	}
 
@@ -164,18 +142,52 @@ func Test_getToken(t *testing.T) {
 			r = r.WithContext(ctx)
 			r.URL.RawQuery = tc.query
 
-			cToken := proxy.getTokenFromCookie(r)
-			qToken := proxy.getTokenFromQueryString(r)
-			var token string
-			if cToken == "" {
-				token = qToken
-			} else {
-				token = cToken
-			}
-			assrt.Equal(tc.want, token)
-			if tc.wantRedirectURL != "" {
-				assrt.Equal(tc.wantRedirectURL, caddyhttp.GetVar(r.Context(), CaddyVarRedirectURL))
-			}
+			token := proxy.getTokenFromCookie(r)
+			assert.Equal(t, tc.want, token, "wrong token in test %q", tc.name)
+		})
+	}
+}
+
+func Test_getTokenFromQueryString(t *testing.T) {
+	secret := []byte("secret")
+	const tokenParam = "token"
+
+	proxy := Proxy{
+		log:        zap.L(),
+		Secret:     secret,
+		TokenParam: tokenParam,
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name: "no token",
+			want: "",
+		},
+		{
+			name:  "token in URL param",
+			query: tokenParam + "=abc123",
+			want:  "abc123",
+		},
+		{
+			name:  "token and returnTo in URL params",
+			query: tokenParam + "=abc123&returnTo=https%3A%2F%2Fexample.com%2Fpath",
+			want:  "abc123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			ctx := context.WithValue(r.Context(), caddy.CtxKey("vars"), map[string]any{})
+			r = r.WithContext(ctx)
+			r.URL.RawQuery = tc.query
+
+			token := proxy.getTokenFromQueryString(r)
+			assert.Equal(t, tc.want, token)
 		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -164,7 +164,14 @@ func Test_getToken(t *testing.T) {
 			r = r.WithContext(ctx)
 			r.URL.RawQuery = tc.query
 
-			token := proxy.getToken(r)
+			cToken := proxy.getTokenFromCookie(r)
+			qToken := proxy.getTokenFromQueryString(r)
+			var token string
+			if cToken == "" {
+				token = qToken
+			} else {
+				token = cToken
+			}
 			assrt.Equal(tc.want, token)
 			if tc.wantRedirectURL != "" {
 				assrt.Equal(tc.wantRedirectURL, caddyhttp.GetVar(r.Context(), CaddyVarRedirectURL))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,7 +3,7 @@
 RED='\033[0;31m'
 RESET='\033[0m'
 
-go test
+go -v test ./...
 
 if [ $? -ne 0 ]; then
   echo -e "\n${RED}One or more tests failed. If this is unexpected, it may be because the test server was still building.${RESET}"


### PR DESCRIPTION
### Fixed
- Fixed the redirect loop that would happen for user agents that do not support cookies.

### Changed (non-breaking)
- Log an error but do not fail if token is not valid
- Split `getToken` into two functions, `getTokenFromQueryString` and `getTokenFromCookie` and move the query string removal redirect into the `handleRequest` function.
- Extract new function `clearQsToken`.
- Extract new function `setCookie`.
- Extract new function `redirectToManagementAPI`.
- Extract new function `getClaimFromToken`.