### PR TITLE
fix cookie bugs

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/cookiejar"
 	"testing"
@@ -86,7 +87,8 @@ func sendRequest(url string, c *http.Cookie) error {
 func weSendARequestWithAuthorizationDataAuthorizingAccess(where, level string) error {
 	var c *http.Cookie
 	url := p.Host
-	token := makeTestJWT(p.Secret, level, time.Now().AddDate(0, 0, 1))
+	expires := time.Now().Add(1000 + time.Second*time.Duration(rand.Intn(1000)))
+	token := makeTestJWT(p.Secret, level, expires)
 
 	if where == "cookie" {
 		c = makeTestJWTCookie(p.CookieName, token)

--- a/main.go
+++ b/main.go
@@ -150,11 +150,20 @@ func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	if flag && cookieClaim.IsValid {
-		p.log.Info("clearing flag")
-		p.clearQueryToken(r)
-		p.clearFlag(r)
-		return nil
+	// if the cookie is valid, it's safe to clear the query string
+	if cookieClaim.IsValid {
+		redirect := false
+		if queryToken != "" {
+			p.clearQueryToken(r)
+			redirect = true
+		}
+		if flag {
+			p.clearFlag(r)
+			redirect = true
+		}
+		if redirect {
+			return nil
+		}
 	}
 
 	returnTo := r.URL.Query().Get(p.ReturnToParam)

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,8 @@ package proxy
 
 import (
 	"context"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 


### PR DESCRIPTION
### Fixed
- Newer token was not replacing an older one. Enforce setting a cookie when the query claim and cookie claim are different.
- Query string was not being cleared when coming from the authorization server. More logic conditions are checked now.