### PR TITLE
get IP-based token without redirect

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -129,14 +131,26 @@ func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 	cookieToken := p.getTokenFromCookie(r)
 	cookieClaim := p.getClaimFromToken(cookieToken)
 
-	if !queryClaim.IsValid && !cookieClaim.IsValid {
-		p.log.Info("no valid token found, calling management api")
-		p.setVar(r, CaddyVarRedirectURL, p.ManagementAPI+p.TokenPath+"?returnTo="+url.QueryEscape(p.Host+r.URL.Path))
-		return nil
-	}
-
 	var token string
 	var claim ProxyClaim
+
+	if !queryClaim.IsValid && !cookieClaim.IsValid {
+		p.log.Info("no valid token found, calling management API")
+		ipAddr, err := getRequestIPAddress(r)
+		if err != nil {
+			p.log.Error("failed to get request IP address", zap.Error(err))
+		} else {
+			token = p.getTokenFromAPI(ipAddr)
+			claim = p.getClaimFromToken(token)
+
+			if !claim.IsValid {
+				p.log.Info("last resort, redirecting to management API")
+				p.setVar(r, CaddyVarRedirectURL, p.ManagementAPI+p.TokenPath+"?returnTo="+url.QueryEscape(p.Host+r.URL.Path))
+				return nil
+			}
+		}
+	}
+
 	if queryClaim.IsValid {
 		token = queryToken
 		claim = queryClaim
@@ -315,6 +329,48 @@ func (p Proxy) getFlag(r *http.Request) bool {
 	return r.URL.Query().Get(CookieFlag) != ""
 }
 
+func (p Proxy) getTokenFromAPI(ipAddress string) string {
+	client := &http.Client{Timeout: time.Second * 10}
+	req, err := http.NewRequest("GET", p.ManagementAPI+p.TokenPath, nil)
+	if err != nil {
+		p.log.Error("error creating management API request", zap.Error(err))
+		return ""
+	}
+
+	req.Header.Add("X-Auth-Proxy-Client-Ip", ipAddress)
+	resp, err := client.Do(req)
+	if err != nil {
+		p.log.Error("management API call failed", zap.Error(err))
+		return ""
+	}
+
+	token, err := io.ReadAll(resp.Body)
+	if err != nil {
+		p.log.Error("failed to read management API response", zap.Error(err))
+		return ""
+	}
+	return string(token)
+}
+
 func claimsAreValidAndDifferent(a, b ProxyClaim) bool {
 	return a.IsValid && b.IsValid && !a.IssuedAt.Time.Equal(b.IssuedAt.Time)
+}
+
+// getRequestIPAddress gets the client IP address from CF-Connecting-IP or RemoteAddr in a request
+func getRequestIPAddress(req *http.Request) (string, error) {
+	if req == nil {
+		return "", errors.New("no request found")
+	}
+
+	// https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip
+	if cf := req.Header.Get("CF-Connecting-IP"); cf != "" {
+		return cf, nil
+	}
+
+	ip, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return "", fmt.Errorf("userip: %q is not IP:port, %w", req.RemoteAddr, err)
+	}
+
+	return ip, nil
 }


### PR DESCRIPTION
[ETH-966](https://itse.youtrack.cloud/issue/ETH-966) Ethnologue Site cannot be verified in Google Search Console

---

### Added
- Try to get a token from the management API before redirecting. This uses a new option on the `GET /auth/token` endpoint to return the token in the body.

This mechanism should work correctly in all situations. When a user has not yet logged into the management API, this will grant them access based on their IP address without having to redirect to the API and back. If they _have_ logged in, the management API should have redirected to Auth Proxy at that time, which would have set a token, causing the token generation process to be bypassed altogether.
