### PR TITLE
Release 1.2.0 -- get IP-based token without redirect

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build and Publish
     needs: test-app
     runs-on: ubuntu-latest
-    if: github.ref_name == 'main'
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -3,7 +3,7 @@ name: Test and Publish
 on:
   push:
     branches: [ '*' ]
-    tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]  # Trigger on version tags like 'v0.1.2'
+    tags: [ 'v*' ]  # Trigger on version tags like 'v0.1.2' or 'v1.2.3-rc.1'
 
 jobs:
   test-app:

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func (p Proxy) handleRequest(w http.ResponseWriter, r *http.Request) error {
 	var claim ProxyClaim
 
 	if !queryClaim.IsValid && !cookieClaim.IsValid {
-		p.log.Info("no valid token found, calling management API")
+		p.log.Info("no valid token found, calling management API", zap.String("URL", p.ManagementAPI+p.TokenPath))
 		ipAddr, err := getRequestIPAddress(r)
 		if err != nil {
 			p.log.Error("failed to get request IP address", zap.Error(err))
@@ -299,7 +299,7 @@ func (p Proxy) getClaimFromToken(token string) ProxyClaim {
 	if errors.Is(err, jwt.ErrTokenExpired) {
 		p.log.Error("jwt token has expired: " + err.Error())
 	} else if err != nil {
-		p.log.Error("failed to parse token: " + err.Error())
+		p.log.Error("failed to parse token", zap.Error(err), zap.String("token", token))
 	} else {
 		claim.IsValid = true
 	}

--- a/main.go
+++ b/main.go
@@ -343,8 +343,7 @@ func (p Proxy) getNewToken(w http.ResponseWriter, r *http.Request) error {
 
 func (p Proxy) getTokenFromAPI(ipAddress string) string {
 	client := &http.Client{Timeout: time.Second * 10}
-	req, err := http.NewRequest("GET", "http://172.17.0.1:53050"+p.TokenPath, nil) // FIXME: DO NOT COMMIT THIS
-	// req, err := http.NewRequest("GET", p.ManagementAPI+p.TokenPath, nil)
+	req, err := http.NewRequest("GET", p.ManagementAPI+p.TokenPath, nil)
 	if err != nil {
 		p.log.Error("error creating management API request", zap.Error(err))
 		return ""


### PR DESCRIPTION
[ETH-966](https://itse.youtrack.cloud/issue/ETH-966) Ethnologue Site cannot be verified in Google Search Console

---

### Added
- Try to get a token from the management API before redirecting. This uses a new option on the `GET /auth/token` endpoint to return the token in the body.

This mechanism should work correctly in all situations. When a user has not yet logged into the management API, this will grant them access based on their IP address without having to redirect to the API and back. If they _have_ logged in, the management API should have redirected to Auth Proxy at that time, which would have set a token, causing the token generation process to be bypassed altogether.
