### PR TITLE
allow bots to bypass authorization and go directly to the default site

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,7 @@ x-common-variables: &test-variables
   COOKIE_NAME: _proxy
   TOKEN_SECRET: Rm9yIEdvZCBzbyBsb3ZlZCB0aGUgd29ybGQgdGhhdCBoZSBnYXZlIGhpcyBvbmUgYW5kIG9ubHkgU29uLCB0aGF0IHdob2V2ZXIgYmVsaWV2ZXMgaW4gaGltIHNoYWxsIG5vdCBwZXJpc2ggYnV0IGhhdmUgZXRlcm5hbCBsaWZlLiAtIEpvaG4gMzoxNg==
   SITES: one:server1:80,two:server2:80,three:server3:80
+  DEFAULT_SITE: server1:80
   MANAGEMENT_API: http://fakemanagementapi:80
 
 services:

--- a/local-example.env
+++ b/local-example.env
@@ -6,6 +6,8 @@ COOKIE_NAME=_auth_proxy
 # Host name is required. Port is optional. Path is ignored.
 # For example: "one:server1.org,two:server2.net,three:server3.com:8080"
 SITES=
+# Site used for proxy when no token is available. Example: "server1.org"
+DEFAULT_SITE=
 # The URL for the management API. Do not include a path or query string
 # For example: https://www.example.com
 MANAGEMENT_API=
@@ -19,3 +21,6 @@ TOKEN_PATH=
 TOKEN_SECRET=
 # disable robots.txt and X-Robots-Tag handling. Default is "false".
 ROBOTS_TXT_DISABLE=false
+# List of trusted bots which are directly proxied to a specific site identified by SITE_DEFAULT. Use
+# comma-separated user agent keywords. Example: "googlebot,duckduckgo"
+TRUSTED_BOTS=

--- a/local-example.env
+++ b/local-example.env
@@ -21,6 +21,6 @@ TOKEN_PATH=
 TOKEN_SECRET=
 # disable robots.txt and X-Robots-Tag handling. Default is "false".
 ROBOTS_TXT_DISABLE=false
-# List of trusted bots which are directly proxied to a specific site identified by SITE_DEFAULT. Use
+# List of trusted bots which are directly proxied to a specific site identified by DEFAULT_SITE. Use
 # comma-separated user agent keywords. Example: "googlebot,duckduckgo"
 TRUSTED_BOTS=

--- a/main_test.go
+++ b/main_test.go
@@ -27,6 +27,7 @@ func Test_AuthProxy(t *testing.T) {
 		CookieName:    cookieName,
 		Secret:        tokenSecret,
 		Sites:         authURLs,
+		DefaultSite:   "default.example.com",
 		log:           zap.L(),
 		ManagementAPI: managementAPI,
 		TokenPath:     tokenPath,
@@ -59,10 +60,10 @@ func Test_AuthProxy(t *testing.T) {
 			wantRedirectURL: ptr(managementAPI + tokenPath + "?returnTo=%2F"),
 		},
 		{
-			name:    "invalid level",
-			url:     "/",
-			cookie:  makeTestJWTCookie(cookieName, makeTestJWT(tokenSecret, "bad", validTime)),
-			wantErr: "not in sites",
+			name:         "default site",
+			url:          "/",
+			cookie:       makeTestJWTCookie(cookieName, makeTestJWT(tokenSecret, "default", validTime)),
+			wantUpstream: ptr("default.example.com"),
 		},
 		{
 			name:            "query valid -- redirect to set cookie",


### PR DESCRIPTION
[ETH-1042](https://itse.youtrack.cloud/issue/ETH-1042) Redirect Error

### Added
- Added configuration value `DEFAULT_SITE`, which is the site used for bots and unrecognized site keys.
- Added optional `TRUSTED_BOTS` configuration that allows for simpler routing for bots. Redirect to the management server is bypassed and the bot is proxied directly to the default site.